### PR TITLE
Add queryString values for interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `queryString` values interpolation.
 
 ## [0.4.0] - 2020-03-06
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,6 @@ All blocks exported by `store-link` share the same props:
 | `variant` | `Variant` | The variant to be used if `displayMode` is `'button'` | `'primary'` |
 | `size` | `Size` | Which predefined size it should use (You can access the [Styleguide documentation](https://styleguide.vtex.com/#/Components/Forms/Button) to understand better how it works). | `'regular'` |
 
-
 ### Variant
 
 To understand better what means each variant it would be better to [access the documentation of our styleguide](https://styleguide.vtex.com/#/Components/Forms/Button). The following variants are the one supported by the button right now:
@@ -93,7 +92,24 @@ You can [access the documentation of our styleguide](https://styleguide.vtex.com
 | `'regular'` |
 | `'large'` |
 
-When creating a Link URL for your `link.product` block, use the variables listed below. With them, you will be able to structure any desired URL for your store, such as a link to a given product department (`/{department}`).
+---
+
+When creating a Link URL you have the query string values available. Example:
+
+```json
+{
+  "link#foo": {
+    "props": {
+      "href": "/login?returnUrl={queryString.returnUrl}",
+      "label": "Sign in"
+    }
+  }
+}
+```
+
+If the current page have the query string `returnUrl` its value will be used, otherwise an empty string will take place.
+
+For the `link.product` block, you can use variables related to the product in context. With them, you will be able to structure any desired URL for your store, such as a link to a given product department (`/{department}`).
 
 | Value value    | Description                                   |
 | -------------- | --------------------------------------------- |

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -8,8 +8,8 @@ import { useProduct } from 'vtex.product-context'
 import { Props, defaultButtonProps } from './StoreLink'
 import hasChildren from './modules/hasChildren'
 import { AvailableContext } from './modules/mappings'
-import interpolateLink from './modules/interpolateLink'
 import useButtonClasses from './modules/useButtonClasses'
+import { useInterpolatedLink } from './modules/useInterpolatedLink'
 
 const { useModalDispatch } = ModalContext
 
@@ -31,8 +31,12 @@ function ProductLink(props: Props) {
   } = props
   const productContext = useProduct()
   const handles = useCssHandles(CSS_HANDLES)
-  const [prevHref, setPrevHref] = useState()
-  const [resolvedLink, setResolvedLink] = useState('#')
+  const resolvedLink = useInterpolatedLink(href, [
+    {
+      type: AvailableContext.product,
+      context: productContext,
+    },
+  ])
   const modalDispatch = useModalDispatch()
 
   const {
@@ -43,16 +47,6 @@ function ProductLink(props: Props) {
   const [shouldReplaceUrl, setShouldReplaceUrl] = useState(
     Boolean(modalDispatch)
   )
-
-  if (prevHref !== href) {
-    setPrevHref(href)
-    const newLink = interpolateLink({
-      link: href,
-      context: productContext,
-      contextType: AvailableContext.product,
-    })
-    setResolvedLink(newLink)
-  }
 
   useEffect(() => {
     // if the link is in a modal it should replace the url instead of just pushing a new one

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -7,6 +7,7 @@ import { ModalContext } from 'vtex.modal-layout'
 
 import hasChildren from './modules/hasChildren'
 import useButtonClasses, { Variant } from './modules/useButtonClasses'
+import { useInterpolatedLink } from './modules/useInterpolatedLink'
 
 type DisplayMode = 'anchor' | 'button'
 type Size = 'small' | 'regular' | 'large'
@@ -56,6 +57,8 @@ function StoreLink(props: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const modalDispatch = useModalDispatch()
   const classes = useButtonClasses({ variant, size })
+  const resolvedLink = useInterpolatedLink(href)
+
   const [shouldReplaceUrl, setShouldReplaceUrl] = useState(
     Boolean(modalDispatch)
   )
@@ -74,7 +77,7 @@ function StoreLink(props: Props) {
 
   return (
     <Link
-      to={href}
+      to={resolvedLink}
       target={target}
       className={rootClasses}
       replace={shouldReplaceUrl}

--- a/react/modules/interpolateLink.ts
+++ b/react/modules/interpolateLink.ts
@@ -2,20 +2,30 @@ import { getMappingFn, AvailableContext } from './mappings'
 
 interface Params {
   link: string
+  namespace?: string
   context?: Record<string, any>
   contextType: AvailableContext
 }
 
 export default function interpolateLink(params: Params) {
-  const { link, context, contextType } = params
+  const { link, namespace, context, contextType } = params
 
   const mapValues = getMappingFn(contextType)
   const variables = mapValues(context)
   let resolvedLink = link
 
   for (const key of Object.keys(variables)) {
-    const regex = new RegExp(`{${key}}`, 'g')
+    const regex = new RegExp(
+      `{${namespace ? `${namespace}.${key}` : key}}`,
+      'g'
+    )
     resolvedLink = resolvedLink.replace(regex, variables[key])
+  }
+
+  // Replace not found variables with empty string
+  if (namespace) {
+    const missingKeys = new RegExp(`{${namespace}.(.*)}`)
+    resolvedLink = resolvedLink.replace(missingKeys, () => '')
   }
 
   return resolvedLink

--- a/react/modules/mappings.ts
+++ b/react/modules/mappings.ts
@@ -48,12 +48,15 @@ export function mapProductValues(context: Record<string, any> = {}) {
 
 export enum AvailableContext {
   product = 'product',
+  queryString = 'queryString',
 }
 
 export function getMappingFn(contextType: AvailableContext) {
   switch (contextType) {
     case AvailableContext.product:
       return mapProductValues
+    case AvailableContext.queryString:
+      return (context: Record<string, string> = {}) => context
     default:
       return () => ({})
   }

--- a/react/modules/useInterpolatedLink.ts
+++ b/react/modules/useInterpolatedLink.ts
@@ -1,0 +1,48 @@
+import { useRuntime } from 'vtex.render-runtime'
+import { useState } from 'react'
+
+import interpolateLink from './interpolateLink'
+import { AvailableContext } from './mappings'
+
+interface Context {
+  type: AvailableContext
+  namespace?: string
+  context: Record<string, unknown>
+}
+
+export const useInterpolatedLink = (
+  href: string,
+  extraContexts?: Context[]
+) => {
+  const [prevHref, setPrevHref] = useState<string | undefined>()
+  const [resolvedLink, setResolvedLink] = useState('#')
+  const {
+    route: { queryString },
+  } = useRuntime()
+
+  const contexts = [
+    {
+      type: AvailableContext.queryString,
+      namespace: 'queryString',
+      context: queryString,
+    },
+    ...(extraContexts ? extraContexts : []),
+  ]
+
+  if (prevHref !== href) {
+    setPrevHref(href)
+
+    const newLink = contexts.reduce((acc, contextInfo) => {
+      return interpolateLink({
+        link: acc,
+        namespace: contextInfo.namespace,
+        context: contextInfo.context,
+        contextType: contextInfo.type,
+      })
+    }, href)
+
+    setResolvedLink(newLink)
+  }
+
+  return resolvedLink
+}

--- a/react/package.json
+++ b/react/package.json
@@ -27,7 +27,7 @@
     "graphql": "^14.5.8",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "typescript": "3.7.3"
+    "typescript": "3.8.3"
   },
   "version": "0.4.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5340,10 +5340,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.7.3:
   version "3.7.5"


### PR DESCRIPTION
#### What does this PR do? \*

Make it possible to use the query string values in URLs.

#### How to test it? \*

With the query string:

1. Open https://breno--storecomponents.myvtex.com/?returnUrl=/foo#
2. Check the link "iaew boy"
3. It should point to "/hey/?returnUrl=/foo"

Without the query string:

1. Open https://breno--storecomponents.myvtex.com/
2. Check the link "iaew boy"
3. It should point to "/hey/?returnUrl=" since there's no queryString `returnUrl`

The block added to the home page is:

```json
  "link#foo": {
    "props": {
      "href": "/hey/?returnUrl={queryString.returnUrl}",
      "label": "Iaew boy"
    }
  },
```

#### Describe alternatives you've considered, if any. \*

none.

#### Related to / Depends on \*

That will help to solve the issue of Gympass 
https://github.com/vtex-apps/challenge-tp-condition/pull/10
