### PR TITLE
Fix prop types of label and buttonProps being optional in code but not in typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - README.md file (fixed the Modus Operandi section).
+- Props `label` and `buttonProps` of `StoreLink`  being optional but not in typescript.
 
 ## [0.6.0] - 2020-06-23
 ### Added

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -17,14 +17,26 @@ export interface ButtonProps {
   size: Size
 }
 
-export interface Props {
-  label: string
+// https://stackoverflow.com/a/49725198/11274053
+type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
+  T,
+  Exclude<keyof T, Keys>
+> &
+  {
+    [K in Keys]-?: Required<Pick<T, K>> &
+      Partial<Record<Exclude<Keys, K>, undefined>>
+  }[Keys]
+
+interface AllProps {
   href: string
-  children: React.ReactNode
+  label: string
   target?: string
+  children: React.ReactNode
   displayMode?: DisplayMode
-  buttonProps: Partial<ButtonProps>
+  buttonProps?: Partial<ButtonProps>
 }
+
+export type Props = RequireOnlyOne<AllProps, 'label' | 'children'>
 
 defineMessages({
   labelTitle: {


### PR DESCRIPTION
#### What problem is this solving?

Optional props of the component not being optional in typescript too.

![image](https://user-images.githubusercontent.com/8517023/87975975-b8133280-caa2-11ea-88e2-a01d7470d59e.png)


<!--- What is the motivation and context for this change? -->

#### How to test it?

1. https://klynger--storecomponents.myvtex.com/
2. Open the quickview
3. It should render ok

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/l2QE4Dep73Evk8OHK/giphy.gif)
