### PR TITLE
Specification group name and specification name use original values of Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Specification group name and specification name use original values of Catalog
 
 ## [0.6.1] - 2020-07-24
 ### Fixed

--- a/react/modules/mappings.ts
+++ b/react/modules/mappings.ts
@@ -17,19 +17,21 @@ function mapCategories(rawCategories: string[]) {
 }
 
 interface SpecificationGroup {
-  name: string
-  specifications?: Array<{ name?: string; values: string[] }>
+  originalName: string
+  specifications?: Array<{ originalName?: string; values: string[] }>
 }
 
 function mapSpecifications(specificationGroups: SpecificationGroup[]) {
   const mappedSpecifications: Record<string, string> = {}
-  specificationGroups.forEach(({ name: groupName, specifications = [] }) => {
-    specifications.forEach(({ name: specificationName, values }) => {
-      const key = `specificationGroups.${groupName}.specifications.${specificationName}`
-      const [value] = values
-      mappedSpecifications[key] = value ?? ''
-    })
-  })
+  specificationGroups.forEach(
+    ({ originalName: groupName, specifications = [] }) => {
+      specifications.forEach(({ originalName: specificationName, values }) => {
+        const key = `specificationGroups.${groupName}.specifications.${specificationName}`
+        const [value] = values
+        mappedSpecifications[key] = value ?? ''
+      })
+    }
+  )
 
   return mappedSpecifications
 }


### PR DESCRIPTION


### What problem is this solving?
Some blocks are having issues with the internationalization of fields in graphql. The `search-graphql` is translating the fields `specificationGroups.name` and `specifications.name`. 

Now, I'm using the original values saved in Catalog: 
`specificationGroups.originalName`
`specifications.originalName`

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[pt-BR](https://pricenew--extensions.myvtex.com/lengow/p?cultureInfo=pt-BR)
[en-US](https://pricenew--extensions.myvtex.com/lengow/p?cultureInfo=en-US)

#### Screenshots or example usage:

<img width="357" alt="Screen Shot 2020-07-28 at 10 47 42 AM" src="https://user-images.githubusercontent.com/32311264/88674183-e48d0700-d0bf-11ea-8dfb-9dcd99b37465.png">

