### PR TITLE
Fix required fields not being required in StoreLink schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Required fields not being required in `StoreLink` schema.
 
 ## [0.7.1] - 2020-12-03
-
 ### Fixed
 - Use search API slugify method for product brand.
 

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -3,6 +3,10 @@
     "StoreLink": {
       "title": "Link",
       "type": "object",
+      "required": [
+        "href",
+        "label"
+      ],
       "properties": {
         "label": {
           "title": "admin/editor.link.label.title",


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace in store home](https://notfoundschema--storecomponents.myvtex.com/)
[Workspace in the new CMS](https://notfoundschema--storecomponents.myvtex.com/admin/app/new-cms/store/landingPage/edit/9a0555c2-6b54-4747-8662-65b1811ab5b1)
[Workspace in site-editor](https://notfoundschema--storecomponents.myvtex.com/admin/cms/site-editor)

Nothing should be different since validation is only used by the new CMS

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/Q7LXQYzZVTKo7Gw0EU/giphy.gif)
