### PR TITLE
Prevention of link propagation in plp

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -131,6 +131,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 
 | CSS Handles         |
 | ------------------- |
+| `linkContainer`     |
 | `childrenContainer` |
 | `label`             |
 | `link`              |

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -65,6 +65,7 @@ function ProductLink(props: Props) {
   const handlePrevent = (e: React.MouseEvent) =>{
     e.stopPropagation()
     e.nativeEvent.stopImmediatePropagation()
+
   }
 
   return (

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -14,6 +14,7 @@ import { useInterpolatedLink } from './modules/useInterpolatedLink'
 const { useModalDispatch } = ModalContext
 
 const CSS_HANDLES = [
+  'linkContainer',
   'link',
   'label',
   'childrenContainer',

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -61,18 +61,26 @@ function ProductLink(props: Props) {
     [classes.label]: displayMode === 'button',
   })
 
+  const handlePrevent = (e: React.MouseEvent) =>{
+    e.stopPropagation()
+    e.nativeEvent.stopImmediatePropagation()
+  }
+
   return (
+    <div onClick={handlePrevent} className={handles.linkContainer}>
     <Link
       target={target}
       to={resolvedLink}
       className={rootClasses}
       replace={shouldReplaceUrl}
+      onClick={handlePrevent}
     >
       {label && <span className={labelClasses}>{label}</span>}
       {hasChildren(children) && displayMode === 'anchor' && (
         <div className={handles.childrenContainer}>{children}</div>
       )}
     </Link>
+    </div>
   )
 }
 

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -39,6 +39,7 @@ function ProductLink(props: Props) {
     },
   ])
   const modalDispatch = useModalDispatch()
+  console.log("test")
 
   const {
     size = defaultButtonProps.size,

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -53,7 +53,7 @@ export const defaultButtonProps: ButtonProps = {
 }
 
 const { useModalDispatch } = ModalContext
-const CSS_HANDLES = ['link', 'label', 'childrenContainer', 'buttonLink']
+const CSS_HANDLES = ['linkContainer','link', 'label', 'childrenContainer', 'buttonLink']
 
 function StoreLink(props: Props) {
   const {
@@ -95,19 +95,27 @@ function StoreLink(props: Props) {
 
   const localizedLabel = formatIOMessage({ id: label, intl })
 
+  const handlePrevent = (e: React.MouseEvent) =>{
+    e.stopPropagation()
+    e.nativeEvent.stopImmediatePropagation()
+  }
+
   return (
+    <div onClick={handlePrevent} className={handles.linkContainer}>
     <Link
       to={resolvedLink}
       target={target}
       className={rootClasses}
       replace={shouldReplaceUrl}
       scrollOptions={scrollOptions}
+      onClick={handlePrevent}
     >
       {label && <span className={labelClasses}>{localizedLabel}</span>}
       {hasChildren(children) && (
         <div className={handles.childrenContainer}>{children}</div>
       )}
     </Link>
+    </div>
   )
 }
 


### PR DESCRIPTION
#### What problem is this solving?
In plp the two components took the link from the product summary and not their own. 
By adding a container div with the appropriate onClick event in which the propagation stops, we were able to overcome the problem. A class with css handles has been associated with the container div so that the style can be managed from the theme.

#### How to test it?
You can try it on the workspace I currently use, where the app with the change is linked.
https://headeracervelione--itwhirlpoolqa.myvtex.com/Prodotti/Lavaggio-e-Asciugatura/Lavatrici