### PR TITLE
Fixed key in regex to remove special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - `escapeLinkRegex` useful option to use a regexp to remove unwanted characters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.8.0] - 2021-02-09
-### Added
-- `escapeLinkRegex` useful option to use a regexp to remove unwanted characters.
 ## [0.7.2] - 2021-01-11
 ### Fixed
 - Required fields not being required in `StoreLink` schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## [0.8.0] - 2021-02-09
+### Added
+- `escapeLinkRegex` useful option to use a regexp to remove unwanted characters.
 ## [0.7.2] - 2021-01-11
 ### Fixed
 - Required fields not being required in `StoreLink` schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- `escapeLinkRegex` useful option to use a regexp to remove unwanted characters.
+
 ## [0.7.2] - 2021-01-11
 ### Fixed
 - Required fields not being required in `StoreLink` schema.

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ All blocks exported by `store-link` share the same props:
 | `target`  | `string` | Where to display the linked URL. This prop works the same way as the target from [HTML `<a>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) (HTML *anchor* element). | `undefined`   |
 | `displayMode` | `enum` | How the link should be displayed. Possible values are: `anchor` (displays a normal link with no styles) or `button` (displays a button that can be customized using the `buttonProps` prop.  | `anchor` |
 | `buttonProps` | `object` | How the link button should be displayed. Use this prop only when the `displayMode` prop is set as `button`. | `{ variant: primary, size: regular }` |
+| `escapeLinkRegex`   | `string` | RegExp, with global match, used to remove special characters within product specifications. (E.g. if you want to use `/[%]/g` then `escapeLinkRegex` = `[%]` )         | `undefined`   |
 
 - `buttonProps` object:
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-link",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "title": "VTEX Store Link",
   "description": "A way to create links in the store",
   "builders": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-link",
-  "version": "0.8.0",
+  "version": "0.7.2",
   "title": "VTEX Store Link",
   "description": "A way to create links in the store",
   "builders": {

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -24,6 +24,7 @@ function ProductLink(props: Props) {
   const {
     label,
     href,
+    escapeLinkRegex,
     children,
     target,
     displayMode = 'anchor',
@@ -31,7 +32,9 @@ function ProductLink(props: Props) {
   } = props
   const productContext = useProduct()
   const handles = useCssHandles(CSS_HANDLES)
-  const resolvedLink = useInterpolatedLink(href, [
+  const resolvedLink = useInterpolatedLink(href,
+    escapeLinkRegex? new RegExp(escapeLinkRegex,"g"):undefined,
+  [
     {
       type: AvailableContext.product,
       context: productContext,

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -32,14 +32,16 @@ function ProductLink(props: Props) {
   } = props
   const productContext = useProduct()
   const handles = useCssHandles(CSS_HANDLES)
-  const resolvedLink = useInterpolatedLink(href,
-    escapeLinkRegex? new RegExp(escapeLinkRegex,"g"):undefined,
-  [
-    {
-      type: AvailableContext.product,
-      context: productContext,
-    },
-  ])
+  const resolvedLink = useInterpolatedLink(
+    href,
+    escapeLinkRegex ? new RegExp(escapeLinkRegex, 'g') : undefined,
+    [
+      {
+        type: AvailableContext.product,
+        context: productContext,
+      },
+    ]
+  )
   const modalDispatch = useModalDispatch()
 
   const {

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -33,7 +33,7 @@ interface AllProps {
   label: string
   target?: string
   scrollTo?: string
-  escapeLinkRegex?:string
+  escapeLinkRegex?: string
   children: React.ReactNode
   displayMode?: DisplayMode
   buttonProps?: Partial<ButtonProps>

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -33,6 +33,7 @@ interface AllProps {
   label: string
   target?: string
   scrollTo?: string
+  escapeLinkRegex?:string
   children: React.ReactNode
   displayMode?: DisplayMode
   buttonProps?: Partial<ButtonProps>

--- a/react/modules/interpolateLink.ts
+++ b/react/modules/interpolateLink.ts
@@ -16,8 +16,9 @@ export default function interpolateLink(params: Params) {
   let resolvedLink = link
 
   for (const key of Object.keys(variables)) {
+    const newKey = key.replace(/[-+%]/g,'')
     const regex = new RegExp(
-      `{${namespace ? `${namespace}.${key}` : key}}`,
+      `{${namespace ? `${namespace}.${newKey}` : newKey}}`,
       'g'
     )
 

--- a/react/modules/interpolateLink.ts
+++ b/react/modules/interpolateLink.ts
@@ -5,10 +5,11 @@ interface Params {
   namespace?: string
   context?: Record<string, any>
   contextType: AvailableContext
+  escapeLinkRegex?:RegExp
 }
 
 export default function interpolateLink(params: Params) {
-  const { link, namespace, context, contextType } = params
+  const { link, namespace, context, contextType , escapeLinkRegex } = params
 
   const mapValues = getMappingFn(contextType)
   const variables = mapValues(context)
@@ -16,11 +17,13 @@ export default function interpolateLink(params: Params) {
   let resolvedLink = link
 
   for (const key of Object.keys(variables)) {
-    const newKey = key.replace(/[^\d\w.]/g,'')
+    let newKey = key
+    if(escapeLinkRegex){
+      newKey = key.replace(escapeLinkRegex,'')
+    }
     const regex = new RegExp(
       `{${namespace ? `${namespace}.${newKey}` : newKey}}`,
       'g'
-
     )
 
     // we slugify the context value so we don't end up with invalid characters on the URL

--- a/react/modules/interpolateLink.ts
+++ b/react/modules/interpolateLink.ts
@@ -5,11 +5,11 @@ interface Params {
   namespace?: string
   context?: Record<string, any>
   contextType: AvailableContext
-  escapeLinkRegex?:RegExp
+  escapeLinkRegex?: RegExp
 }
 
 export default function interpolateLink(params: Params) {
-  const { link, namespace, context, contextType , escapeLinkRegex } = params
+  const { link, namespace, context, contextType, escapeLinkRegex } = params
 
   const mapValues = getMappingFn(contextType)
   const variables = mapValues(context)
@@ -18,8 +18,8 @@ export default function interpolateLink(params: Params) {
 
   for (const key of Object.keys(variables)) {
     let newKey = key
-    if(escapeLinkRegex){
-      newKey = key.replace(escapeLinkRegex,'')
+    if (escapeLinkRegex) {
+      newKey = key.replace(escapeLinkRegex, '')
     }
     const regex = new RegExp(
       `{${namespace ? `${namespace}.${newKey}` : newKey}}`,

--- a/react/modules/interpolateLink.ts
+++ b/react/modules/interpolateLink.ts
@@ -16,10 +16,11 @@ export default function interpolateLink(params: Params) {
   let resolvedLink = link
 
   for (const key of Object.keys(variables)) {
-    const newKey = key.replace(/[-+%]/g,'')
+    const newKey = key.replace(/[^\d\w.]/g,'')
     const regex = new RegExp(
       `{${namespace ? `${namespace}.${newKey}` : newKey}}`,
       'g'
+
     )
 
     // we slugify the context value so we don't end up with invalid characters on the URL

--- a/react/modules/useInterpolatedLink.ts
+++ b/react/modules/useInterpolatedLink.ts
@@ -12,6 +12,7 @@ interface Context {
 
 export const useInterpolatedLink = (
   href: string,
+  escapeLinkRegex?: RegExp,
   extraContexts?: Context[]
 ) => {
   const [prevHref, setPrevHref] = useState<string | undefined>()
@@ -38,6 +39,7 @@ export const useInterpolatedLink = (
         namespace: contextInfo.namespace,
         context: contextInfo.context,
         contextType: contextInfo.type,
+        escapeLinkRegex : escapeLinkRegex
       })
     }, href)
 

--- a/react/modules/useInterpolatedLink.ts
+++ b/react/modules/useInterpolatedLink.ts
@@ -39,7 +39,7 @@ export const useInterpolatedLink = (
         namespace: contextInfo.namespace,
         context: contextInfo.context,
         contextType: contextInfo.type,
-        escapeLinkRegex : escapeLinkRegex
+        escapeLinkRegex,
       })
     }, href)
 

--- a/react/package.json
+++ b/react/package.json
@@ -20,6 +20,7 @@
     "@types/react": "^16.9.19",
     "@vtex/test-tools": "^3.3.2",
     "@vtex/tsconfig": "^0.4.4",
+    "husky": "^5.0.9",
     "typescript": "3.9.7"
   },
   "version": "0.7.2"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -3058,6 +3058,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+husky@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-5.0.9.tgz#6d38706643d66ed395bcd4ee952d02e3f15eb3a3"
+  integrity sha512-0SjcaY21a+IRdx7p7r/X33Vc09UR2m8SbP8yfkhUX2/jAmwcz+GR7i9jXkp2pP3GfX23JhMkVP6SWwXB18uXtg==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
#### What problem is this solving?

The regex in the InterpolateLink.ts file threw an error when it encountered special characters. Solution, created a new key by removing the special characters in the previous one.

#### How to test it?
Create a specification attribute that includes "+++-50%" and try to take the value of any other specification with link.product, with the previous version an error is triggered, in the current one the value is taken correctly.
Ws with previous version: https://sendtomiguel--itwhirlpoolqa.myvtex.com/Prodotti/Lavaggio-e-Asciugatura/Lavatrici
Ws with fixed version: https://pullregex--itwhirlpoolqa.myvtex.com/Prodotti/Lavaggio-e-Asciugatura/Lavatrici

The link.product is the one highlighted in the image.
![image](https://user-images.githubusercontent.com/73878310/106159518-29841a00-6185-11eb-9028-f95ce0d40f82.png)
