### PR TITLE
Fixing Links breaking when href was undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- undefined `href` breaking StoreLink and ProductLink
 
 ## [0.7.4] - 2021-03-08
 ### Fixed

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -29,7 +29,7 @@ type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
   }[Keys]
 
 interface AllProps {
-  href: string
+  href?: string
   label: string
   target?: string
   scrollTo?: string

--- a/react/modules/useInterpolatedLink.ts
+++ b/react/modules/useInterpolatedLink.ts
@@ -7,7 +7,7 @@ import { AvailableContext } from './mappings'
 import type { Context } from '../typings/types'
 
 export const useInterpolatedLink = (
-  href: string,
+  href?: string,
   escapeLinkRegex?: RegExp,
   extraContexts?: Context[]
 ) => {
@@ -17,6 +17,10 @@ export const useInterpolatedLink = (
   } = useRuntime() as RenderContext.RenderContext
 
   useEffect(() => {
+    if (!href) {
+      return
+    }
+
     const contexts: Context[] = [
       {
         type: AvailableContext.queryString,


### PR DESCRIPTION
#### What problem is this solving?

This PR fixes a behavior that broke the Link components, introduced by the last version (it's already deprecated). I've also fixed the types used for `href` so other people don't get misled as I did :)

#### How to test it?

The menus and submenus on the header are full of `href`less links. On version of `vtex.store-link@0.7.3` this menus broke on hover.

[Workspace](https://icarovtexlink--muji.myvtex.com/?__bindingAddress=www.mujionline.eu/uk)