### PR TITLE
Fix issue of store-link always using history replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Logic of history replace.
 
 ## [0.7.5] - 2021-03-09
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "vtex.css-handles": "0.x",
     "vtex.product-context": "0.x",
-    "vtex.modal-layout": "0.x",
     "vtex.native-types": "0.x"
   },
   "registries": [

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import classnames from 'classnames'
 import { Link } from 'vtex.render-runtime'
 import { useCssHandles } from 'vtex.css-handles'
-import { ModalContext } from 'vtex.modal-layout'
 import { useProduct } from 'vtex.product-context'
 
 import { Props, defaultButtonProps } from './StoreLink'
@@ -10,8 +9,6 @@ import hasChildren from './modules/hasChildren'
 import { AvailableContext } from './modules/mappings'
 import useButtonClasses from './modules/useButtonClasses'
 import { useInterpolatedLink } from './modules/useInterpolatedLink'
-
-const { useModalDispatch } = ModalContext
 
 const CSS_HANDLES = [
   'link',
@@ -56,21 +53,11 @@ function ProductLink(props: Props) {
     extraContexts
   )
 
-  const modalDispatch = useModalDispatch()
-
   const {
     size = defaultButtonProps.size,
     variant = defaultButtonProps.variant,
   } = buttonProps
   const classes = useButtonClasses({ variant, size })
-  const [shouldReplaceUrl, setShouldReplaceUrl] = useState(
-    Boolean(modalDispatch)
-  )
-
-  useEffect(() => {
-    // if the link is in a modal it should replace the url instead of just pushing a new one
-    setShouldReplaceUrl(Boolean(modalDispatch))
-  }, [modalDispatch])
 
   const rootClasses = classnames(handles.link, {
     [`${handles.buttonLink} ${classes.container}`]: displayMode === 'button',
@@ -81,12 +68,7 @@ function ProductLink(props: Props) {
   })
 
   return (
-    <Link
-      target={target}
-      to={resolvedLink}
-      className={rootClasses}
-      replace={shouldReplaceUrl}
-    >
+    <Link target={target} to={resolvedLink} className={rootClasses}>
       {label && <span className={labelClasses}>{label}</span>}
       {hasChildren(children) && displayMode === 'anchor' && (
         <div className={handles.childrenContainer}>{children}</div>

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -3,7 +3,6 @@ import classnames from 'classnames'
 import { Link } from 'vtex.render-runtime'
 import { defineMessages, useIntl } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
-import { ModalContext } from 'vtex.modal-layout'
 import { formatIOMessage } from 'vtex.native-types'
 
 import hasChildren from './modules/hasChildren'
@@ -53,7 +52,6 @@ export const defaultButtonProps: ButtonProps = {
   size: 'regular',
 }
 
-const { useModalDispatch } = ModalContext
 const CSS_HANDLES = ['link', 'label', 'childrenContainer', 'buttonLink']
 
 function StoreLink(props: Props) {
@@ -72,12 +70,11 @@ function StoreLink(props: Props) {
   }
   const intl = useIntl()
   const handles = useCssHandles(CSS_HANDLES)
-  const modalDispatch = useModalDispatch()
-  const classes = useButtonClasses({ variant, size })
+  const classes = useButtonClasses({
+    variant,
+    size,
+  })
   const resolvedLink = useInterpolatedLink(href)
-
-  const hasModalContext = modalDispatch.toString() !== 'function () {}'
-  const shouldReplaceUrl = hasModalContext
 
   const rootClasses = classnames(handles.link, {
     [`${handles.buttonLink} ${classes.container}`]: displayMode === 'button',
@@ -89,14 +86,16 @@ function StoreLink(props: Props) {
 
   const scrollOptions = scrollTo ? { baseElementId: scrollTo } : undefined
 
-  const localizedLabel = formatIOMessage({ id: label, intl })
+  const localizedLabel = formatIOMessage({
+    id: label,
+    intl,
+  })
 
   return (
     <Link
       to={resolvedLink}
       target={target}
       className={rootClasses}
-      replace={shouldReplaceUrl}
       scrollOptions={scrollOptions}
     >
       {label && <span className={labelClasses}>{localizedLabel}</span>}

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import classnames from 'classnames'
 import { Link } from 'vtex.render-runtime'
 import { defineMessages, useIntl } from 'react-intl'
@@ -76,13 +76,8 @@ function StoreLink(props: Props) {
   const classes = useButtonClasses({ variant, size })
   const resolvedLink = useInterpolatedLink(href)
 
-  const [shouldReplaceUrl, setShouldReplaceUrl] = useState(
-    Boolean(modalDispatch)
-  )
-
-  useEffect(() => {
-    setShouldReplaceUrl(Boolean(modalDispatch))
-  }, [modalDispatch])
+  const hasModalContext = modalDispatch.toString() !== 'function () {}'
+  const shouldReplaceUrl = hasModalContext
 
   const rootClasses = classnames(handles.link, {
     [`${handles.buttonLink} ${classes.container}`]: displayMode === 'button',

--- a/react/__mocks__/vtex.modal-layout.ts
+++ b/react/__mocks__/vtex.modal-layout.ts
@@ -1,3 +1,0 @@
-export const ModalContext = {
-  useModalDispatch: () => {},
-}

--- a/react/modules/useInterpolatedLink.ts
+++ b/react/modules/useInterpolatedLink.ts
@@ -1,6 +1,5 @@
 import { useRuntime } from 'vtex.render-runtime'
 import { useEffect, useState } from 'react'
-import type { RenderContext } from 'vtex.render-runtime'
 
 import interpolateLink from './interpolateLink'
 import { AvailableContext } from './mappings'
@@ -14,7 +13,7 @@ export const useInterpolatedLink = (
   const [resolvedLink, setResolvedLink] = useState('#')
   const {
     route: { queryString },
-  } = useRuntime() as RenderContext.RenderContext
+  } = useRuntime()
 
   useEffect(() => {
     if (!href) {

--- a/react/package.json
+++ b/react/package.json
@@ -23,7 +23,6 @@
     "husky": "^5.0.9",
     "typescript": "3.9.7",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.modal-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.9.0/public/@types/vtex.modal-layout",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.128.2/public/@types/vtex.render-runtime",

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,8 @@
     "vtex.modal-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.9.0/public/@types/vtex.modal-layout",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.128.2/public/@types/vtex.render-runtime",
+    "vtex.store-link": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.7.5/public/@types/vtex.store-link"
   },
   "version": "0.7.5"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5348,10 +5348,6 @@ verror@1.10.0:
   version "0.4.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.modal-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.9.0/public/@types/vtex.modal-layout":
-  version "0.9.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.modal-layout@0.9.0/public/@types/vtex.modal-layout#18696b6f97ee5d582bf938bbcb8dc63220689022"
-
 "vtex.native-types@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types":
   version "0.7.5"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types#52d8c0b675fcdf2b6b1ca93f6a99a630519f618f"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5360,9 +5360,13 @@ verror@1.10.0:
   version "0.9.7"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.9.7/public/@types/vtex.product-context#4024c589f1ba318e92219a88bf18b4e3774dc85c"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
-  version "8.126.11"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.128.2/public/@types/vtex.render-runtime":
+  version "8.128.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.128.2/public/@types/vtex.render-runtime#67f5975f7edd73c9afa7bee57734540c0ead5428"
+
+"vtex.store-link@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.7.5/public/@types/vtex.store-link":
+  version "0.7.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.7.5/public/@types/vtex.store-link#d4e4f98ac6fcac948deb3283b6c3f915fae26c1a"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
~useModalDispatch() always exists, it should check if it's a noop function or a real function instead~
Logic of closing modal as moved to modal-layout: https://github.com/vtex-apps/modal-layout/blob/master/react/Modal.tsx#L61-L72

#### What problem is this solving?

Fix issue https://github.com/vtex-apps/store-discussion/issues/550

#### How to test it?

https://brenovtex--oficinareserva.myvtex.com/

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
