### PR TITLE
Feature/title attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `title` attribute for links.
+
 ## [0.8.1] - 2021-08-09
 ### Fixed
 - Outdated typings from VTEX apps.

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ All blocks exported by `store-link` share the same props:
 | `buttonProps` | `object` | How the link button should be displayed. Use this prop only when the `displayMode` prop is set as `button`. | `{ variant: primary, size: regular }` |
 | `escapeLinkRegex`   | `string` | RegExp, with global match, used to remove special characters within product specifications. (E.g. if you want to use `/[%]/g` then `escapeLinkRegex` = `[%]` )         | `undefined`   |
 | `rel` | `string` | This prop specifies the relationship between the current document and the linked document (for better SEO). This prop works the same way as the `rel` attribute from `<a>`, the [HTML anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a). Supported values can be found [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types) | `undefined` |
+| `title` | `string` | This prop adds the [title](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title) global attribute to the link, which can be any `string` or identical to the link text passing the `"{label}"` value. | `undefined` |
 
 - `buttonProps` object:
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -6,5 +6,7 @@
   "admin/editor.link.target.title": "Where to open the link",
   "admin/editor.link.target.description": "You can check the options available at: https://developer.mozilla.org/docs/Web/HTML/Element/a",
   "admin/editor.link.rel.attribute.title": "\"rel\" attribute",
-  "admin/editor.link.rel.attribute.description": "You can check the options available at: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types"
+  "admin/editor.link.rel.attribute.description": "You can check the options available at: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types",
+  "admin/editor.link.title.attribute.title": "\"title\" Attribute",
+  "admin/editor.link.title.attribute.description": "You can check more information at: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,5 +6,7 @@
   "admin/editor.link.target.title": "Where to open the link",
   "admin/editor.link.target.description": "You can check the options available at: https://developer.mozilla.org/docs/Web/HTML/Element/a",
   "admin/editor.link.rel.attribute.title": "\"rel\" attribute",
-  "admin/editor.link.rel.attribute.description": "You can check the options available at: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types"
+  "admin/editor.link.rel.attribute.description": "You can check the options available at: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types",
+  "admin/editor.link.title.attribute.title": "\"title\" attribute",
+  "admin/editor.link.title.attribute.description": "You can check more information at: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,5 +6,7 @@
   "admin/editor.link.target.title": "Donde abrir el link",
   "admin/editor.link.target.description": "Puede consultar las opciones disponibles en: https://developer.mozilla.org/docs/Web/HTML/Element/a",
   "admin/editor.link.rel.attribute.title": "\"rel\" atributo",
-  "admin/editor.link.rel.attribute.description": "Puedes consultar las opciones disponibles aquí: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types"
+  "admin/editor.link.rel.attribute.description": "Puedes consultar las opciones disponibles aquí: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types",
+  "admin/editor.link.title.attribute.title": "\"title\" atributo",
+  "admin/editor.link.title.attribute.description": "Puedes consultar más información en: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -6,5 +6,7 @@
   "admin/editor.link.target.title": "Onde abrir o link",
   "admin/editor.link.target.description": "Você pode checar as opções disponíveis em: https://developer.mozilla.org/docs/Web/HTML/Element/a",
   "admin/editor.link.rel.attribute.title": "\"rel\" atributo",
-  "admin/editor.link.rel.attribute.description": "Você pode checar as opções disponíveis em: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types"
+  "admin/editor.link.rel.attribute.description": "Você pode checar as opções disponíveis em: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types",
+  "admin/editor.link.title.attribute.title": "\"title\" atributo",
+  "admin/editor.link.title.attribute.description": "Você pode checar mais informações em: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title"
 }

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -77,7 +77,7 @@ function ProductLink(props: Props) {
       to={resolvedLink}
       className={rootClasses}
       rel={rel}
-      {...{ title }}
+      title={title}
     >
       {label && <span className={labelClasses}>{label}</span>}
       {hasChildren(children) && displayMode === 'anchor' && (

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -9,7 +9,7 @@ import hasChildren from './modules/hasChildren'
 import { AvailableContext } from './modules/mappings'
 import useButtonClasses from './modules/useButtonClasses'
 import { useInterpolatedLink } from './modules/useInterpolatedLink'
-import { useTitleAttr } from './modules/useTitleAttr'
+import { useTitleAttribute } from './modules/useTitleAttribute'
 
 const CSS_HANDLES = [
   'link',
@@ -69,7 +69,7 @@ function ProductLink(props: Props) {
     [classes.label]: displayMode === 'button',
   })
 
-  const title = useTitleAttr(props.title, label)
+  const title = useTitleAttribute(props.title, label)
 
   return (
     <Link

--- a/react/ProductLink.tsx
+++ b/react/ProductLink.tsx
@@ -9,6 +9,7 @@ import hasChildren from './modules/hasChildren'
 import { AvailableContext } from './modules/mappings'
 import useButtonClasses from './modules/useButtonClasses'
 import { useInterpolatedLink } from './modules/useInterpolatedLink'
+import { useTitleAttr } from './modules/useTitleAttr'
 
 const CSS_HANDLES = [
   'link',
@@ -68,8 +69,16 @@ function ProductLink(props: Props) {
     [classes.label]: displayMode === 'button',
   })
 
+  const title = useTitleAttr(props.title, label)
+
   return (
-    <Link target={target} to={resolvedLink} className={rootClasses} rel={rel}>
+    <Link
+      target={target}
+      to={resolvedLink}
+      className={rootClasses}
+      rel={rel}
+      {...{ title }}
+    >
       {label && <span className={labelClasses}>{label}</span>}
       {hasChildren(children) && displayMode === 'anchor' && (
         <div className={handles.childrenContainer}>{children}</div>

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -104,7 +104,7 @@ function StoreLink(props: Props) {
       className={rootClasses}
       scrollOptions={scrollOptions}
       rel={rel}
-      {...{ title }}
+      title={title}
     >
       {label && <span className={labelClasses}>{localizedLabel}</span>}
       {hasChildren(children) && (

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -8,6 +8,7 @@ import { formatIOMessage } from 'vtex.native-types'
 import hasChildren from './modules/hasChildren'
 import useButtonClasses, { Variant } from './modules/useButtonClasses'
 import { useInterpolatedLink } from './modules/useInterpolatedLink'
+import { useTitleAttr } from './modules/useTitleAttr'
 
 type DisplayMode = 'anchor' | 'button'
 type Size = 'small' | 'regular' | 'large'
@@ -37,6 +38,7 @@ interface AllProps {
   displayMode?: DisplayMode
   buttonProps?: Partial<ButtonProps>
   rel?: string
+  title?: string
 }
 
 export type Props = RequireOnlyOne<AllProps, 'label' | 'children'>
@@ -93,6 +95,8 @@ function StoreLink(props: Props) {
     intl,
   })
 
+  const title = useTitleAttr(props.title, label)
+
   return (
     <Link
       to={resolvedLink}
@@ -100,6 +104,7 @@ function StoreLink(props: Props) {
       className={rootClasses}
       scrollOptions={scrollOptions}
       rel={rel}
+      {...{ title }}
     >
       {label && <span className={labelClasses}>{localizedLabel}</span>}
       {hasChildren(children) && (

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -8,7 +8,7 @@ import { formatIOMessage } from 'vtex.native-types'
 import hasChildren from './modules/hasChildren'
 import useButtonClasses, { Variant } from './modules/useButtonClasses'
 import { useInterpolatedLink } from './modules/useInterpolatedLink'
-import { useTitleAttr } from './modules/useTitleAttr'
+import { useTitleAttribute } from './modules/useTitleAttribute'
 
 type DisplayMode = 'anchor' | 'button'
 type Size = 'small' | 'regular' | 'large'
@@ -95,7 +95,7 @@ function StoreLink(props: Props) {
     intl,
   })
 
-  const title = useTitleAttr(props.title, label)
+  const title = useTitleAttribute(props.title, label)
 
   return (
     <Link

--- a/react/__mocks__/vtex.render-runtime.tsx
+++ b/react/__mocks__/vtex.render-runtime.tsx
@@ -10,6 +10,10 @@ export const useRuntime = () => {
   }
 }
 
-export function Link({ to, children, label = children }: any) {
-  return <a href={to}>{label}</a>
+export function Link({ to, children, label = children, title }: any) {
+  return (
+    <a href={to} title={title}>
+      {label}
+    </a>
+  )
 }

--- a/react/__tests__/StoreLink.test.tsx
+++ b/react/__tests__/StoreLink.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
-import { screen, render } from '@vtex/test-tools/react'
+import { render } from '@vtex/test-tools/react'
 
 import StoreLink from '../StoreLink'
 
 test('StoreLink Component', () => {
-  render(<StoreLink href="/custom-link" label="View More" title="View More" />)
+  const { getByTitle } = render(
+    <StoreLink href="/custom-link" label="View More" title="View More" />
+  )
 
-  const link = screen.getByTitle('View More')
+  const link = getByTitle('View More')
 
   expect(link).toBeInTheDocument()
   expect(link).toHaveTextContent('View More')

--- a/react/__tests__/StoreLink.test.tsx
+++ b/react/__tests__/StoreLink.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { screen, render } from '@vtex/test-tools/react'
+
+import StoreLink from '../StoreLink'
+
+test('StoreLink Component', () => {
+  render(<StoreLink href="/custom-link" label="View More" title="View More" />)
+
+  const link = screen.getByTitle('View More')
+
+  expect(link).toBeInTheDocument()
+  expect(link).toHaveTextContent('View More')
+  expect(link).toHaveAttribute('href', '/custom-link')
+  expect(link).toHaveAttribute('title', 'View More')
+})

--- a/react/modules/useTitleAttr.ts
+++ b/react/modules/useTitleAttr.ts
@@ -1,0 +1,18 @@
+import { useIntl } from 'react-intl'
+import { formatIOMessage } from 'vtex.native-types'
+
+/**
+ * @export
+ * @description Validates if the title attribute must be equal to the link text by the `label` prop.
+ * @param title The link title.
+ * @param label The link text.
+ * @return The title atribute.
+ * @version 1.0.0
+ */
+export const useTitleAttr = (title?: string, label = '') => {
+  const intl = useIntl()
+  const titleAttr = formatIOMessage({ id: title, intl }, { label }) as string
+
+  // Returns `undefined` if it is an empty title to not render the attribute.
+  return titleAttr || undefined
+}

--- a/react/modules/useTitleAttribute.ts
+++ b/react/modules/useTitleAttribute.ts
@@ -6,13 +6,16 @@ import { formatIOMessage } from 'vtex.native-types'
  * @description Validates if the title attribute must be equal to the link text by the `label` prop.
  * @param title The link title.
  * @param label The link text.
- * @return The title atribute.
+ * @return The title attribute.
  * @version 1.0.0
  */
-export const useTitleAttr = (title?: string, label = '') => {
+export const useTitleAttribute = (title?: string, label = '') => {
   const intl = useIntl()
-  const titleAttr = formatIOMessage({ id: title, intl }, { label }) as string
+  const titleAttribute = formatIOMessage(
+    { id: title, intl },
+    { label }
+  ) as string
 
   // Returns `undefined` if it is an empty title to not render the attribute.
-  return titleAttr || undefined
+  return titleAttribute || undefined
 }

--- a/react/package.json
+++ b/react/package.json
@@ -25,8 +25,8 @@
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.native-types": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.native-types@0.7.5/public/@types/vtex.native-types",
     "vtex.product-context": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.131.0/public/@types/vtex.render-runtime",
-    "vtex.store-link": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.7.6/public/@types/vtex.store-link"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime",
+    "vtex.store-link": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.8.1/public/@types/vtex.store-link"
   },
   "version": "0.8.1"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5356,13 +5356,13 @@ verror@1.10.0:
   version "0.10.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.product-context@0.10.0/public/@types/vtex.product-context#c5e2a97b404004681ee12f4fff7e6b62157786cc"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.131.0/public/@types/vtex.render-runtime":
-  version "8.131.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.131.0/public/@types/vtex.render-runtime#dcc88828e3d65ecb4e7538a3623a4b1ddd77e034"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime":
+  version "8.132.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.132.3/public/@types/vtex.render-runtime#c7dd142e384f38bd7a7c841543b73e9349fadc93"
 
-"vtex.store-link@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.7.6/public/@types/vtex.store-link":
-  version "0.7.6"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.7.6/public/@types/vtex.store-link#147e80f808d06503492d6b844ebf8de5a7ed0bd9"
+"vtex.store-link@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.8.1/public/@types/vtex.store-link":
+  version "0.8.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-link@0.8.1/public/@types/vtex.store-link#a69c5217b1f121e286fdc6b2d4ee66d8198db0f0"
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -27,6 +27,11 @@
           "title": "admin/editor.link.rel.attribute.title",
           "type": "string",
           "description": "admin/editor.link.rel.attribute.description"
+        },
+        "title": {
+          "title": "admin/editor.link.title.attribute.title",
+          "type": "string",
+          "description": "admin/editor.link.title.attribute.description"
         }
       }
     },


### PR DESCRIPTION
#### What problem is this solving?

Thoe Store Link component accepts a `children` component, enabling a textless link. For example, a link with an icon only. This is bad for accessibility, and with a title attribute, we can solve this by improving the semantics of the links.

#### How to test it?

You can check the `title` attribute in the header's wishlist link.

![image](https://user-images.githubusercontent.com/48245692/135868874-a45ee7ed-37e1-4d91-a028-c04c0f2d40b6.png)


[Workspace](https://titleattr--trackandfieldio.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/48245692/135678627-74a6a38b-89c7-4495-a3e0-b5915cac6bca.png)

![image](https://user-images.githubusercontent.com/48245692/135678702-9b6f4291-4e9c-449a-859a-89bdab973d6f.png)

![image](https://user-images.githubusercontent.com/48245692/135678767-46674344-6870-4c94-a531-7f7dc99bdf28.png)

![image](https://user-images.githubusercontent.com/48245692/135868473-aa164618-9e7f-49ef-9144-cbc196d99494.png)

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/xSM46ernAUN3y/giphy.gif)
