### PR TITLE
Stop click event propagation for StoreLink.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed 
+- Fixed click event propagation for store-link.
 ## [0.9.3] - 2023-05-05
 ### Fixed
 - Fixes of i18n on readme.md according to task LOC-10597.

--- a/react/StoreLink.tsx
+++ b/react/StoreLink.tsx
@@ -92,6 +92,10 @@ function StoreLink(props: Props) {
     id: label,
     intl,
   })
+  const handleClick = (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+  }
 
   return (
     <Link
@@ -100,6 +104,7 @@ function StoreLink(props: Props) {
       className={rootClasses}
       scrollOptions={scrollOptions}
       rel={rel}
+      onClick={handleClick}
     >
       {label && <span className={labelClasses}>{localizedLabel}</span>}
       {hasChildren(children) && (


### PR DESCRIPTION
#### What problem is this solving?

StoreLink component did not stop event propagation which lead to redirecting to product paged instead of login page.

#### How to test it?

Can be tested on https://mcc--riviera.myvtex.com/motosapatoare-motoburghie

